### PR TITLE
Update knockstrap.nuspec

### DIFF
--- a/knockstrap.nuspec
+++ b/knockstrap.nuspec
@@ -15,7 +15,7 @@
         <dependencies>
             <dependency id="knockoutjs" version="2.0.0" />
             <dependency id="jQuery" version="1.9.0" />
-            <dependency id="Twitter.Bootstrap" version="3.0.0" />
+            <dependency id="Bootstrap" version="3.0.0" />
         </dependencies>
     </metadata>
     <files>


### PR DESCRIPTION
The appropriate nuget package for bootstrap is now apparently 'Bootstrap' rather than 'Twitter.Bootstrap'
