### PR TITLE
Have Modal binding set input focus

### DIFF
--- a/src/bindings/modalBinding.js
+++ b/src/bindings/modalBinding.js
@@ -66,6 +66,7 @@
 
         $element.on('shown.bs.modal', function () {
             value.visible(true);
+            $(this).find("[autofocus]:first").focus();
         });
 
         $element.on('hidden.bs.modal', function () {


### PR DESCRIPTION
When the Modal shown event is thrown, find the first element with the "autofocus" HTML5 attribute and set the focus to that element.
