### PR TITLE
Changed AMD module name from jQuery to official jquery

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@
         factory(require('knockout'), require('jquery'));
     } else if (typeof define === 'function' && define.amd) {
         // AMD
-        define(moduleName, ['knockout', 'jQuery'], factory);
+        define(moduleName, ['knockout', 'jquery'], factory);
     } else {
         factory(ko, $);
     }


### PR DESCRIPTION
 Source: http://requirejs.org/docs/jquery.html

```
jQuery defines named AMD module 'jquery' (all lower case) when it detects AMD/RequireJS.
To reduce confusion, we recommend using 'jquery' as the module name in your require.config.
```

From jQuery 2.1.1 source (Line ~9137):

``` javascript
// Register as a named AMD module, since jQuery can be concatenated with other
// files that may use define, but not via a proper concatenation script that
// understands anonymous AMD modules. A named AMD is safest and most robust
// way to register. Lowercase jquery is used because AMD module names are
// derived from file names, and jQuery is normally delivered in a lowercase
// file name. Do this after creating the global so that if an AMD module wants
// to call noConflict to hide this version of jQuery, it will work.

// Note that for maximum portability, libraries that are not jQuery should
// declare themselves as anonymous modules, and avoid setting a global if an
// AMD loader is present. jQuery is a special case. For more information, see
// https://github.com/jrburke/requirejs/wiki/Updating-existing-libraries#wiki-anon

if ( typeof define === "function" && define.amd ) {
    define( "jquery", [], function() {
        return jQuery;
    });
}
```
