### PR TITLE
Modal visiblity binding fixes

### DIFF
--- a/src/bindings/modalBinding.js
+++ b/src/bindings/modalBinding.js
@@ -68,14 +68,14 @@
         $element.modal(options);
 
         $element.on('shown.bs.modal', function () {
-            if (typeof value.visible !== 'undefined' && typeof value.visible === "function" && !ko.isComputed(value.visible)) {
+            if (typeof value.visible !== 'undefined' && typeof value.visible === 'function' && !ko.isComputed(value.visible)) {
                 value.visible(true);
             }
 
             $(this).find("[autofocus]:first").focus();
         });
 
-        if (typeof value.visible !== 'undefined' && typeof value.visible === "function" && !ko.isComputed(value.visible)) {
+        if (typeof value.visible !== 'undefined' && typeof value.visible === 'function' && !ko.isComputed(value.visible)) {
             $element.on('hidden.bs.modal', function() {
                 value.visible(false);
             });

--- a/src/bindings/modalBinding.js
+++ b/src/bindings/modalBinding.js
@@ -68,14 +68,14 @@
         $element.modal(options);
 
         $element.on('shown.bs.modal', function () {
-            if (typeof value.visible !== 'undefined') {
+            if (typeof value.visible !== 'undefined' && typeof value.visible === "function" && !ko.isComputed(value.visible)) {
                 value.visible(true);
             }
 
             $(this).find("[autofocus]:first").focus();
         });
 
-        if (typeof value.visible !== 'undefined') {
+        if (typeof value.visible !== 'undefined' && typeof value.visible === "function" && !ko.isComputed(value.visible)) {
             $element.on('hidden.bs.modal', function() {
                 value.visible(false);
             });


### PR DESCRIPTION
Only attempt to set the visibility value if the binding is a function and isn't a ko.computed(). Otherwise errors are thrown at runtime.