### PR TITLE
Use anonymous module when exporting via AMD

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 ﻿// @echo header
-(function (moduleName, factory) {
+(function (factory) {
     'use strict';
 
     if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
@@ -7,12 +7,12 @@
         factory(require('knockout'), require('jquery'));
     } else if (typeof define === 'function' && define.amd) {
         // AMD
-        define(moduleName, ['knockout', 'jquery'], factory);
+        define(['knockout', 'jquery'], factory);
     } else {
         factory(ko, $);
     }
 
-})('knockstrap', function (ko, $) {
+})(function (ko, $) {
     'use strict';
     
     // @include utils.js


### PR DESCRIPTION
Knockstrap currently uses a hardcoded module name when exporting via AMD, which is not recommended practice. I noticed this when trying to use knockstrap, but finding it would only load if served from the root path, because that is the only way the `require()`'d module ID matches the hardcoded name.

This change only impacts users loading knockstrap via AMD. It does not affect them if they serve knockstrap from the root path (ie at `/knockstrap.js`), which is the only way it works normally anyway. Anyone else loading knockstrap via AMD on a non-root path would already be using `path` and `map` config to work around the problem, so they should also be unaffected. Basically there is little downside to this change.

 Here are some further references:
- [RequireJS documentation advising against named modules](http://requirejs.org/docs/api.html#modulename)
- [similar problem with moment.js leading eventually to them switching to anonymous AMD export](https://github.com/moment/moment/issues/1095)
- [moment.js PR switching to anonymous module](https://github.com/moment/moment/pull/1963)
- [chai.js issue: Self Named Module is not good](https://github.com/chaijs/chai/issues/362)
- [RequireJS wiki on why to use anonymous modules](https://github.com/jrburke/requirejs/wiki/Updating-existing-libraries#register-as-an-anonymous-module-)
- [A StackOverflow Q&A on the topic](http://stackoverflow.com/questions/19720646/named-module-vs-unnamed-module-in-requirejs)

Examples of other knockout plugins (all using anonymous module defines):
- [knockout.punches](https://github.com/mbest/knockout.punches/blob/master/build/fragments/pre.js)
- [knockout-projections](https://github.com/SteveSanderson/knockout-projections/blob/master/src/knockout-projections.js)
- [knockout-es5](https://github.com/SteveSanderson/knockout-es5/blob/master/src/knockout-es5.js)
