### PR TITLE
Fix radioBinding using value with quote causes exception in jQuery 2.x

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -147,7 +147,7 @@
                 options: {
                     specs: ['tests/utilsBehaviors.js', 'tests/stringTemplateEngineBehaviors.js', 'tests/bindings/*.js'],
                     vendor: [
-                        'http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js',
+                        'http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js',
                         'http://netdna.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js',
                         'http://cdnjs.cloudflare.com/ajax/libs/knockout/3.0.0/knockout-min.js'
                     ],

--- a/src/bindings/radioBinding.js
+++ b/src/bindings/radioBinding.js
@@ -20,7 +20,8 @@ ko.bindingHandlers.radio = {
     },
 
     update: function (element, valueAccessor) {
-        var $radioButton = $(element).find('input[value="' + ko.unwrap(valueAccessor()) + '"]'),
+        var value = ko.unwrap(valueAccessor()) || '',
+            $radioButton = $(element).find('input[value="' + value.replace(/"/g, '\\"') + '"]'),
             $radioButtonWrapper;
 
         if ($radioButton.length) {

--- a/tests/bindings/radioBindingBehaviors.js
+++ b/tests/bindings/radioBindingBehaviors.js
@@ -2,6 +2,7 @@
     this.prepareTestElement('<div class="btn-group form-group" data-toggle="buttons" data-bind="radio: value">'
         + '<label class="btn btn-primary"><input type="radio" name="options" value="A" />A</label>'
         + '<label class="btn btn-primary"><input type="radio" name="options" value="B" />B</label>'
+        + '<label class="btn btn-primary"><input type="radio" name="options" value="X&quot;" />X&quot;</label>'
         + '</div>');
 
     it('Should throw exception for non-observable value', function() {
@@ -39,6 +40,8 @@
         expect(this.testElement.find('.active input:checked')).toHaveValue('B');
         vm.value('A');
         expect(this.testElement.find('.active input:checked')).toHaveValue('A');
+        vm.value('X"');
+        expect(this.testElement.find('.active input:checked')).toHaveValue('X"');
     });
     
     it('Should change value according to clicked button', function () {
@@ -80,7 +83,7 @@
 
         ko.applyBindings(vm, this.testElement[0]);
 
-        this.testElement.children().eq(2).click();
+        this.testElement.children().eq(3).click();
         jasmine.clock().tick(1);
         expect(vm.value()).toEqual('C');
         


### PR DESCRIPTION
When using jQuery 2.x, a `radio` binding with a value that contains a double quote `"` causes an exception.

Fix tested to work in both jQuery 1.10.x and 2.x.