### PR TITLE
Prioritise loading reference to knockout and jQuery from global context

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
                 browser: true,
                 sub: true,
                 globals: {
-                    $: false,
+                    jQuery: false,
                     ko: false,
                     require: false,
                     exports: false,

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,11 @@
 ﻿// @echo header
 (function (factory) {
     'use strict';
-
+    
+    if (ko && jQuery) {
+        //global knockout and jQuery references already present, so use these regardless of whether this module has been included in CommonJS/AMD
+        factory(ko, jQuery);
+    }
     if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
         // CommonJS/Node.js
         factory(require('knockout'), require('jquery'));
@@ -9,7 +13,7 @@
         // AMD
         define(['knockout', 'jquery'], factory);
     } else {
-        factory(ko, $);
+        console.error('Could not locate current context reference to knockout and jQuery in order to load Knockstrap');
     }
 
 })(function (ko, $) {

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@
 (function (factory) {
     'use strict';
     
-    if (ko && jQuery) {
+    if (typeof ko !== undefined && typeof jQuery !== undefined) {
         //global knockout and jQuery references already present, so use these regardless of whether this module has been included in CommonJS/AMD
         factory(ko, jQuery);
     } else if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@
         // AMD
         define(['knockout', 'jquery'], factory);
     } else {
-        console.error('Could not locate current context reference to knockout and jQuery in order to load Knockstrap');
+        throw new Error('Could not locate current context reference to knockout and jQuery in order to load Knockstrap');
     }
 
 })(function (ko, $) {

--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,7 @@
     if (ko && jQuery) {
         //global knockout and jQuery references already present, so use these regardless of whether this module has been included in CommonJS/AMD
         factory(ko, jQuery);
-    }
-    if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
+    } else if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
         // CommonJS/Node.js
         factory(require('knockout'), require('jquery'));
     } else if (typeof define === 'function' && define.amd) {


### PR DESCRIPTION
Fixes #35 

If knockout and jQuery are defined on the global context already, then there is no need to call those libraries again. Doing so would most likely create conflicts anyway.