### PR TITLE
Show new popover content when dynamically updated

### DIFF
--- a/src/bindings/popoverBinding.js
+++ b/src/bindings/popoverBinding.js
@@ -72,6 +72,11 @@ ko.bindingHandlers.popover = {
             });
         } else {
             ko.utils.extend(popoverData.options, options);
+            if(popoverData.options.content) {
+                $element.popover('show');
+            } else {
+                $element.popover('hide');
+            }
         }
     }
 };


### PR DESCRIPTION
When the content is just static text, the content isn't updated without this.