### PR TITLE
Use the official Bootstrap NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "jquery": ">=1.9.0",
     "knockout": ">=2.3.0",
-    "twitter-bootstrap-3.0.0": "~3"
+    "bootstrap": "~3"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
The previous package being used was an unofficial one created by someone else that seems to be stuck on 3.0.0.

The official TWBS Bootstrap package name is just `bootstrap` and it is now up to 3.3.7.